### PR TITLE
Release 0.3.1

### DIFF
--- a/queue/build.gradle
+++ b/queue/build.gradle
@@ -28,11 +28,11 @@ publishing {
 
 dependencies {
 	// Coroutine support
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.2"
     
     // JUnit 5
-    testImplementation platform("org.junit:junit-bom:5.7.2")
+    testImplementation platform("org.junit:junit-bom:5.8.2")
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.junit.jupiter:junit-jupiter-params"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"

--- a/queue/build.gradle
+++ b/queue/build.gradle
@@ -20,7 +20,7 @@ publishing {
 		maven(MavenPublication) {
 			groupId = "io.github.dk96-os.coroutines"
 			artifactId = "queue"
-			version = "0.3"
+			version = "0.3.1"
 			from components.java
 		}
 	}

--- a/queue/build.gradle
+++ b/queue/build.gradle
@@ -74,11 +74,11 @@ tasks.jacocoTestCoverageVerification {
 		rule {
 			limit {
 				counter = "INSTRUCTION"
-				minimum = 0.85
+				minimum = 0.93
 			}
 			limit {
 				counter = "BRANCH"
-				minimum = 0.85
+				minimum = 0.93
 			}
 		}
 	}

--- a/queue/build.gradle
+++ b/queue/build.gradle
@@ -74,11 +74,11 @@ tasks.jacocoTestCoverageVerification {
 		rule {
 			limit {
 				counter = "INSTRUCTION"
-				minimum = 0.93
+				minimum = 0.96
 			}
 			limit {
 				counter = "BRANCH"
-				minimum = 0.93
+				minimum = 0.96
 			}
 		}
 	}

--- a/queue/src/main/kotlin/coroutines/queue/CoroutineQueue.kt
+++ b/queue/src/main/kotlin/coroutines/queue/CoroutineQueue.kt
@@ -1,15 +1,15 @@
 package coroutines.queue
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import java.util.*
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CancellationException
-import kotlin.collections.ArrayList
 
-/** Simple Queue for awaiting asynchronous coroutines
+/** A Queue for organizing asynchronous coroutines.
  * @author DK96-OS : 2021 - 2022
  */
 class CoroutineQueue<T>(
@@ -25,18 +25,23 @@ class CoroutineQueue<T>(
 	val count: Int
 		get() = mQueue.size
 	
-	/** Add a deferred result to the Queue
-	 * @return True if the queue allowed the task to be added (didn't exceed capacity) */
+	/** Add a deferred result to the Queue.
+	 * @param task The Task to be inserted into the Queue.
+	 * @return True if the queue allowed the task to be added (didn't exceed capacity)
+	 */
 	fun add(
 		task: Deferred<T?>
 	) : Boolean = mQueue.offer(task)
 
-	/** Block until next coroutine finishes, 
-	  * @return null if empty queue or task result is nullable  */
+	/** Wait for the first coroutine in the Queue, return it's result..
+	 * @return The result of the first task, or null if Queue is empty.
+	 */
 	suspend fun awaitNext()
 	: T? = mQueue.poll()?.await()
 
-	/** Await each element in the queue, add it to a list and return the list */
+	/** Await each element in the queue, add it to a list and return the list
+	 * @return An ArrayList containing the results of all tasks in the queue.
+	 */
 	suspend fun awaitList()
 	: ArrayList<T> {
 		var task: Deferred<T?>? = mQueue.poll()
@@ -50,21 +55,48 @@ class CoroutineQueue<T>(
 		return list
 	}
 
-    /** Block thread until queue is empty */
-	suspend fun awaitAll() {
+    /** Wait for a group of tasks to complete.
+     * @param limit The maximum number of tasks to wait for. zero is unlimited.
+     * @return The number of tasks that were waited on.
+     */
+	suspend fun awaitAll(
+	    limit: Int = 0,
+	) : Int {
+	    // Count the number of tasks that are waited for.
+	    var taskCount = 0
+	    // Get the next Task in the Queue
 		var task: Deferred<T?>? = mQueue.poll()
 		while (task != null) {
+			// Wait for the task to complete
 			task.await()
+			// Increment the counter, check if limit is reached
+			if (++taskCount == limit) return limit
+			// Get the next task
 			task = mQueue.poll()
 		}
+	    return taskCount
 	}
 
-	/** Tries to cancel everything in the queue */
+	/** Tries to cancel everything in the queue.
+	 * @param cause An Exception to be passed to all cancelled tasks.
+	 * @return The number of tasks that were cancelled.
+	 */
 	fun cancel(
-		cause: CancellationException? = null
-	) {
-		mQueue.forEach { it.cancel(cause) }
-		mQueue.clear()
+		cause: CancellationException? = null,
+	) : Int {
+		// Count the number of affected tasks
+		var taskCount = 0
+		// Get and cancel all tasks
+		var task = mQueue.poll()
+		while (task != null) {
+			// Cancel this task
+			task.cancel(cause)
+			// Increment the counter
+			++taskCount
+			// Get the next task
+			task = mQueue.poll()
+		}
+		return taskCount
 	}
 
 	companion object {
@@ -75,23 +107,22 @@ class CoroutineQueue<T>(
 		 * @param transform The suspending transformation operation.
 		 * @return A new ArrayList containing the non-null transformation products.
 		 */
-		suspend fun <A, B> transformList(
+		fun <A, B> transformList(
+			coroutineScope: CoroutineScope,
 			input: List<A>,
 			transform: suspend (A) -> B?
 		) : ArrayList<B> {
 			if (1 < input.size) {
 				val queue = CoroutineQueue<B>(input.size)
-				coroutineScope {
-					input.forEach { a ->
-						queue.add(async(Dispatchers.IO) {
-							transform(a)
-						})
-					}
+				input.forEach { a ->
+					queue.add(coroutineScope.async(Dispatchers.IO) {
+						transform(a)
+					})
 				}
-				return queue.awaitList()
+				return runBlocking { queue.awaitList() }
 			} else if (input.size == 1) {
 				// The input list has only one element
-				val result = transform(input[0])
+				val result = runBlocking { transform(input[0]) }
 				if (result != null)
 					return arrayListOf(result)
 			}
@@ -105,26 +136,27 @@ class CoroutineQueue<T>(
 		 * @param transform The suspending transformation operation.
 		 * @return A new ArrayList containing the non-null transformation products.
 		 */
-		suspend fun <A, B> transformArray(
+		fun <A, B> transformArray(
+			coroutineScope: CoroutineScope,
 			input: Array<A>,
-			transform: suspend (A) -> B?
+			transform: suspend (A) -> B?,
 		) : ArrayList<B> {
 			if (input.size < 2) {
 				if (input.size == 1) {
-					val result = transform(input[0])
+					val result = runBlocking {
+						transform(input[0])
+					}
 					if (result != null)
 						return arrayListOf(result)
 				}
 			} else {
 				val queue = CoroutineQueue<B>(input.size)
-				coroutineScope {
-					input.forEach { a ->
-						queue.add(async(Dispatchers.IO) {
-							transform(a)
-						})
-					}
+				input.forEach { a ->
+					queue.add(coroutineScope.async(Dispatchers.IO) {
+						transform(a)
+					})
 				}
-				return queue.awaitList()
+				return runBlocking { queue.awaitList() }
 			}
 			// By default, return new empty ArrayList
 			return ArrayList(0)

--- a/queue/src/test/kotlin/coroutines/queue/CoroutineQueueCompanionTest.kt
+++ b/queue/src/test/kotlin/coroutines/queue/CoroutineQueueCompanionTest.kt
@@ -33,7 +33,7 @@ class CoroutineQueueCompanionTest {
 	@Test
 	fun testTransformListEmptyList() {
 		runBlocking {
-			val result = transformList(emptyList<InputData>()) {
+			val result = transformList(this, emptyList<InputData>()) {
 				it.transform()
 			}
 			assertEquals(
@@ -50,7 +50,7 @@ class CoroutineQueueCompanionTest {
 			)
 		)
 		runBlocking {
-			val result = transformList(input) {
+			val result = transformList(this, input) {
 				it.transform()
 			}
 			assertEquals(
@@ -70,7 +70,7 @@ class CoroutineQueueCompanionTest {
 			)
 		)
 		runBlocking {
-			val result: ArrayList<OutputData> = transformList(input) {
+			val result: ArrayList<OutputData> = transformList(this, input) {
 				it.transform()
 				null
 			}
@@ -83,7 +83,7 @@ class CoroutineQueueCompanionTest {
 	@Test
 	fun testTransformListFunction() {
 		runBlocking {
-			val output = transformList(inputList) {
+			val output = transformList(this, inputList) {
 				it.transform()
 			}
 			assertEquals(
@@ -103,6 +103,7 @@ class CoroutineQueueCompanionTest {
 				1, 2, 3, 4, 5, 6
 			)
 			val output = transformList(
+				this,
 				nullTestInputs
 			) {
 				when {
@@ -129,7 +130,7 @@ class CoroutineQueueCompanionTest {
 	@Test
 	fun testTransformArray() {
 		runBlocking {
-			val output = transformArray(inputArray) {
+			val output = transformArray(this, inputArray) {
 				it.transform()
 			}
 			assertEquals(
@@ -148,7 +149,7 @@ class CoroutineQueueCompanionTest {
 			InputData(77, byteArrayOf(4, 2, 4, 6))
 		}
 		runBlocking {
-			val output = transformArray(input) {
+			val output = transformArray(this, input) {
 				it.transform()
 			}
 			assertEquals(
@@ -167,12 +168,27 @@ class CoroutineQueueCompanionTest {
 	}
 
 	@Test
+	fun testTransformArrayEmpty() {
+		val input = Array(0) {
+			InputData(77, byteArrayOf(4, 2, 4, 6))
+		}
+		runBlocking {
+			val output = transformArray(this, input) {
+				it.transform()
+			}
+			assertEquals(
+				0, output.size
+			)
+		}
+	}
+
+	@Test
 	fun testTransformArraySingleNull() {
 		val input = Array(1) {
 			InputData(77, byteArrayOf(4, 2, 4, 6))
 		}
 		runBlocking {
-			val output: ArrayList<OutputData> = transformArray(input) {
+			val output: ArrayList<OutputData> = transformArray(this, input) {
 				null
 			}
 			assertEquals(


### PR DESCRIPTION
## Release 0.3.1
Following objectives outlined in previous release #7.

## Enhancements
Those described in #6 improve the utility of the `awaitAll` method, providing advantages in many cases where detailed control over completion and the results of coroutines is necessary.

### Testing Standard Increase
As it is important to continuously improve the standards for testing, even if only by a small amount, an increase of some sort is expected alongside this release.

This time, it will be an increase in code coverage limits from 85 to 93 in both branches and instructions. New branches will be added when #6 is implemented, and this will help offset the difficulty in reaching higher coverage.