### PR TITLE
Queue Capacity

### DIFF
--- a/queue/src/main/kotlin/coroutines/queue/CoroutineQueue.kt
+++ b/queue/src/main/kotlin/coroutines/queue/CoroutineQueue.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import java.util.*
-import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CancellationException
 
 /** A Queue for organizing asynchronous coroutines.
@@ -18,9 +17,7 @@ class CoroutineQueue<T>(
 ) {
 	
     private val mQueue
-    : Queue<Deferred<T?>> = ArrayBlockingQueue(
-	    capacity, true
-    )
+    : Deque<Deferred<T?>> = ArrayDeque(capacity)
 
 	val count: Int
 		get() = mQueue.size


### PR DESCRIPTION
Modify the Coroutine Queue Capacity. Allow the capacity to be flexible, or fixed depending on the constructor parameter.

Resolve #4 