### PR TITLE
Release 0.3.3

### DIFF
--- a/queue/build.gradle
+++ b/queue/build.gradle
@@ -20,7 +20,7 @@ publishing {
 		maven(MavenPublication) {
 			groupId = "io.github.dk96-os.coroutines"
 			artifactId = "queue"
-			version = "0.3.2"
+			version = "0.3.3"
 			from components.java
 		}
 	}

--- a/queue/src/test/kotlin/coroutines/examples/InputData.kt
+++ b/queue/src/test/kotlin/coroutines/examples/InputData.kt
@@ -1,13 +1,22 @@
 package coroutines.examples
 
-/** Data structure used as coroutine input for tests
+/** Data structure used as coroutine input for tests.
+ * @author DK96-OS : 2022
  */
 class InputData(
 	val key: Byte,
 	val stream: ByteArray,
 ) {
-	/** Produce an Output data from this Input data
+
+	/** Produce an Output from this Input.
+	 * @param returnNull Whether to return null instead of OutputData.
 	 */
-	fun transform()
-	: OutputData = OutputData(key, String(stream))
+	fun transform(
+		returnNull: Boolean = false,
+	) : OutputData? = if (returnNull)
+		null
+	else OutputData(
+		key, String(stream)
+	)
+
 }

--- a/queue/src/test/kotlin/coroutines/queue/CoroutineQueueCompanionTest.kt
+++ b/queue/src/test/kotlin/coroutines/queue/CoroutineQueueCompanionTest.kt
@@ -155,7 +155,7 @@ class CoroutineQueueCompanionTest {
 			assertEquals(
 				1, output.size
 			)
-			val expectedOutput = input[0].transform()
+			val expectedOutput = input[0].transform()!!
 			assertEquals(
 				expectedOutput.key,
 				output[0].key

--- a/queue/src/test/kotlin/coroutines/queue/QueueTestingTemplate.kt
+++ b/queue/src/test/kotlin/coroutines/queue/QueueTestingTemplate.kt
@@ -1,0 +1,58 @@
+package coroutines.queue
+
+import coroutines.examples.InputData
+import coroutines.examples.OutputData
+import coroutines.examples.TestDataProvider
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+
+/** A Template for [CoroutineQueue] Tests.
+ * @author DK96-OS : 2022
+ */
+abstract class QueueTestingTemplate(
+    protected val inputDataSize: Int = 32,
+    inputRNG: Long = 300,
+) {
+
+    init {
+        if (0 > inputDataSize)
+            throw IllegalArgumentException()
+    }
+
+    /** A Test Data Provider.
+     */
+    protected val provider = TestDataProvider()
+
+    /** Example Input Data that can be transformed easily.
+     */
+    protected val input: List<InputData> = provider.createInput(
+        inputDataSize, inputRNG
+    ).toList()
+
+    /** A CoroutineQueue instance created before each test.
+     */
+    protected lateinit var queue: CoroutineQueue<OutputData>
+
+    /** Initialize a new CoroutineQueue with the given capacity.
+     *  Also, generate an array of InputData with size equal to capacity.
+     *  @param capacity Default is 32.
+     */
+    protected fun init(
+        capacity: Int = 32,
+    ) {
+        queue = CoroutineQueue(capacity)
+    }
+
+    /** Create a transformation coroutine for all inputs, add them to Queue.
+     *  All transformations will return non-null OutputData.
+     */
+    protected fun addAllInputData() {
+        runBlocking {
+            for (i in input) {
+                val task = async { i.transform() }
+                queue.add(task)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Enhance `awaitList` method by adding arguments to limit the number of coroutine tasks that may be affected by this call.

### New Arguments
The first argument, __limit__ a specific quantitative parameter, provides an upper limit on the size of the data that will be returned.

A second argument, __countNull__ a qualitative boolean parameter, enables two use cases:
1. Where the number of tasks in the Queue is important, and the upper limit should apply here.
2. Where the size of the output list is important, and null results should be ignored.

### Default Values
The default __limit__ is zero, which (along with negative numbers) will not restrict the number of tasks or the size of the returned list.

The default value of __countNull__ is true, which is a more conservative behaviour that will do less and return smaller lists when queue tasks may return null. It leads to predictable queue behaviour when coroutine tasks are known and controlled carefully.